### PR TITLE
Edit install script to generate from unfilled desktop shortcut 

### DIFF
--- a/coindicator.desktop
+++ b/coindicator.desktop
@@ -7,5 +7,3 @@ Type=Application
 Categories=Utility;Network;
 Keywords=crypto;coin;ticker;price;exchange;
 StartupNotify=false
-Exec=/home/sander/code/coinprice-indicator/run.sh
-Icon=/home/sander/code/coinprice-indicator/resources/logo_248px.png

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Install system dependencies
-sudo apt-get install python3-venv python3-pygame libcairo2-dev libdbus-glib-1-2 gir1.2-gtk-3.0 gir1.2-appindicator3-0.1 -y
+sudo apt-get install python3-venv libcairo2-dev libdbus-glib-1-2 gir1.2-gtk-3.0 gir1.2-appindicator3-0.1 -y
+pip3 install pygame
 # Install environment
 python3 -m venv --system-site-packages ./
 source ./bin/activate


### PR DESCRIPTION
coindicator. desktop is contained some absolute path 
and python3-pygame is also not found 

so I decided to remove 2 rows in the desktop shortcut (install.sh is filling it anyway)
and change apt-get pygame into pip3 install pygame

